### PR TITLE
Chaincode server shim side#fab 14086

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.2
-	github.com/hyperledger/fabric-protos-go v0.0.0-20190821214336-621b908d5022
+	github.com/hyperledger/fabric-protos-go v0.0.0-20190919234611-2a87503ac7c9
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/hyperledger/fabric-protos-go v0.0.0-20190821214336-621b908d5022 h1:WzttYAPO5xkQ87ZrxzEhvDZknfarSNu1PZt3NPMTE3Y=
 github.com/hyperledger/fabric-protos-go v0.0.0-20190821214336-621b908d5022/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
+github.com/hyperledger/fabric-protos-go v0.0.0-20190919234611-2a87503ac7c9 h1:JgFP410JY/3uQQGcfxR1HUDdDnPWzmC0TlmPctPElCQ=
+github.com/hyperledger/fabric-protos-go v0.0.0-20190919234611-2a87503ac7c9/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/hyperledger/fabric-protos-go v0.0.0-20190821214336-621b908d5022 h1:WzttYAPO5xkQ87ZrxzEhvDZknfarSNu1PZt3NPMTE3Y=
-github.com/hyperledger/fabric-protos-go v0.0.0-20190821214336-621b908d5022/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/hyperledger/fabric-protos-go v0.0.0-20190919234611-2a87503ac7c9 h1:JgFP410JY/3uQQGcfxR1HUDdDnPWzmC0TlmPctPElCQ=
 github.com/hyperledger/fabric-protos-go v0.0.0-20190919234611-2a87503ac7c9/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/shim/chaincodeserver.go
+++ b/shim/chaincodeserver.go
@@ -1,0 +1,50 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package shim
+
+import (
+	"errors"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim/internal"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+)
+
+// ChaincodeServer encapsulates basic properties needed for a chaincode server
+type ChaincodeServer struct {
+	Name    string
+	Address string
+	CC      Chaincode
+}
+
+// Connect the bidi stream entry point called by chaincode to register with the Peer.
+func (cs *ChaincodeServer) Connect(stream pb.Chaincode_ConnectServer) error {
+	return chatWithPeer(cs.Name, stream, cs.CC)
+}
+
+// Start the server
+func (cs *ChaincodeServer) Start() error {
+	if cs.Name == "" {
+		return errors.New("name must be specified")
+	}
+
+	if cs.Address == "" {
+		return errors.New("address must be specified")
+	}
+
+	if cs.CC == nil {
+		return errors.New("chaincode must be specified")
+	}
+
+	// create listener and grpc server
+	server, err := internal.NewServer(cs.Address, nil)
+	if err != nil {
+		return err
+	}
+
+	// register the server with grpc ...
+	pb.RegisterChaincodeServer(server.Server, cs)
+
+	// ... and start
+	return server.Start()
+}

--- a/shim/chaincodeserver.go
+++ b/shim/chaincodeserver.go
@@ -4,28 +4,48 @@
 package shim
 
 import (
+	"crypto/tls"
 	"errors"
 
 	"github.com/hyperledger/fabric-chaincode-go/shim/internal"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
+
+	"google.golang.org/grpc/keepalive"
 )
+
+// TLSProperties passed to ChaincodeServer
+type TLSProperties struct {
+	//Disabled forces default to be TLS enabled
+	Disabled bool
+	Key      []byte
+	Cert     []byte
+	// ClientCACerts set if connecting peer should be verified
+	ClientCACerts []byte
+}
 
 // ChaincodeServer encapsulates basic properties needed for a chaincode server
 type ChaincodeServer struct {
-	Name    string
+	// CCID should match chaincode's package name on peer
+	CCID string
+	// Addesss is the listen address of the chaincode server
 	Address string
-	CC      Chaincode
+	// CC is the chaincode that handles Init and Invoke
+	CC Chaincode
+	// TLSProps is the TLS properties passed to chaincode server
+	TLSProps TLSProperties
+	// KaOpts keepalive options, sensible defaults provided if nil
+	KaOpts *keepalive.ServerParameters
 }
 
 // Connect the bidi stream entry point called by chaincode to register with the Peer.
 func (cs *ChaincodeServer) Connect(stream pb.Chaincode_ConnectServer) error {
-	return chatWithPeer(cs.Name, stream, cs.CC)
+	return chatWithPeer(cs.CCID, stream, cs.CC)
 }
 
 // Start the server
 func (cs *ChaincodeServer) Start() error {
-	if cs.Name == "" {
-		return errors.New("name must be specified")
+	if cs.CCID == "" {
+		return errors.New("ccid must be specified")
 	}
 
 	if cs.Address == "" {
@@ -36,8 +56,17 @@ func (cs *ChaincodeServer) Start() error {
 		return errors.New("chaincode must be specified")
 	}
 
+	var tlsCfg *tls.Config
+	var err error
+	if !cs.TLSProps.Disabled {
+		tlsCfg, err = internal.LoadTLSConfig(true, cs.TLSProps.Key, cs.TLSProps.Cert, cs.TLSProps.ClientCACerts)
+		if err != nil {
+			return err
+		}
+	}
+
 	// create listener and grpc server
-	server, err := internal.NewServer(cs.Address, nil)
+	server, err := internal.NewServer(cs.Address, tlsCfg, cs.KaOpts)
 	if err != nil {
 		return err
 	}

--- a/shim/handler.go
+++ b/shim/handler.go
@@ -20,10 +20,16 @@ const (
 	ready       state = "ready"       // ready for requests
 )
 
-// PeerChaincodeStream interface for stream between Peer and chaincode instance.
+// PeerChaincodeStream is the common stream interface for Peer - chaincode communication.
+// Both chaincode-as-server and chaincode-as-client patterns need to support this
 type PeerChaincodeStream interface {
 	Send(*pb.ChaincodeMessage) error
 	Recv() (*pb.ChaincodeMessage, error)
+}
+
+// ClientStream supports the (original) chaincode-as-client interaction pattern
+type ClientStream interface {
+	PeerChaincodeStream
 	CloseSend() error
 }
 

--- a/shim/handler_test.go
+++ b/shim/handler_test.go
@@ -13,9 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//go:generate counterfeiter -o internal/mock/peer_chaincode_stream.go --fake-name PeerChaincodeStream . chaincodeStream
+//go:generate counterfeiter -o internal/mock/peer_chaincode_stream.go --fake-name PeerChaincodeStream . peerChaincodeStream
 
-type chaincodeStream interface{ PeerChaincodeStream }
+type peerChaincodeStream interface{ PeerChaincodeStream }
+
+//go:generate counterfeiter -o internal/mock/client_stream.go --fake-name ClientStream . clientStream
+
+type clientStream interface{ ClientStream }
 
 type mockChaincode struct {
 	errMsg       string

--- a/shim/internal/config.go
+++ b/shim/internal/config.go
@@ -17,14 +17,14 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-// Config ...
+// Config contains chaincode's configuration
 type Config struct {
 	ChaincodeName string
 	TLS           *tls.Config
 	KaOpts        keepalive.ClientParameters
 }
 
-// LoadConfig ...
+// LoadConfig loads the chaincode configuration
 func LoadConfig() (Config, error) {
 	var err error
 	tlsEnabled, err := strconv.ParseBool(os.Getenv("CORE_PEER_TLS_ENABLED"))
@@ -87,20 +87,63 @@ func LoadConfig() (Config, error) {
 		return Config{}, fmt.Errorf("failed to read root cert file: %s", err)
 	}
 
-	rootCertPool := x509.NewCertPool()
-	if ok := rootCertPool.AppendCertsFromPEM(root); !ok {
-		return Config{}, errors.New("failed to load root cert file")
-	}
-	clientCert, err := tls.X509KeyPair(cert, key)
+	tlscfg, err := LoadTLSConfig(false, key, cert, root)
 	if err != nil {
-		return Config{}, errors.New("failed to parse client key pair")
+		return Config{}, err
 	}
 
-	conf.TLS = &tls.Config{
+	conf.TLS = tlscfg
+
+	return conf, nil
+}
+
+// LoadTLSConfig loads the TLS configuration for the chaincode
+func LoadTLSConfig(isserver bool, key, cert, root []byte) (*tls.Config, error) {
+	if key == nil {
+		return nil, fmt.Errorf("key not provided")
+	}
+
+	if cert == nil {
+		return nil, fmt.Errorf("cert not provided")
+	}
+
+	if !isserver && root == nil {
+		return nil, fmt.Errorf("root cert not provided")
+	}
+
+	cccert, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, errors.New("failed to parse client key pair")
+	}
+
+	var rootCertPool *x509.CertPool
+	if root != nil {
+		rootCertPool = x509.NewCertPool()
+		if ok := rootCertPool.AppendCertsFromPEM(root); !ok {
+			return nil, errors.New("failed to load root cert file")
+		}
+	}
+
+	tlscfg := &tls.Config{
 		MinVersion:   tls.VersionTLS12,
-		Certificates: []tls.Certificate{clientCert},
+		Certificates: []tls.Certificate{cccert},
 		RootCAs:      rootCertPool,
 	}
 
-	return conf, nil
+	//follow Peer's server default config properties
+	if isserver {
+		tlscfg.SessionTicketsDisabled = true
+		tlscfg.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		}
+		if rootCertPool != nil {
+			tlscfg.ClientAuth = tls.RequireAndVerifyClientCert
+		}
+	}
+
+	return tlscfg, nil
 }

--- a/shim/internal/mock/client_stream.go
+++ b/shim/internal/mock/client_stream.go
@@ -7,7 +7,17 @@ import (
 	"github.com/hyperledger/fabric-protos-go/peer"
 )
 
-type PeerChaincodeStream struct {
+type ClientStream struct {
+	CloseSendStub        func() error
+	closeSendMutex       sync.RWMutex
+	closeSendArgsForCall []struct {
+	}
+	closeSendReturns struct {
+		result1 error
+	}
+	closeSendReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RecvStub        func() (*peer.ChaincodeMessage, error)
 	recvMutex       sync.RWMutex
 	recvArgsForCall []struct {
@@ -35,7 +45,59 @@ type PeerChaincodeStream struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *PeerChaincodeStream) Recv() (*peer.ChaincodeMessage, error) {
+func (fake *ClientStream) CloseSend() error {
+	fake.closeSendMutex.Lock()
+	ret, specificReturn := fake.closeSendReturnsOnCall[len(fake.closeSendArgsForCall)]
+	fake.closeSendArgsForCall = append(fake.closeSendArgsForCall, struct {
+	}{})
+	fake.recordInvocation("CloseSend", []interface{}{})
+	fake.closeSendMutex.Unlock()
+	if fake.CloseSendStub != nil {
+		return fake.CloseSendStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.closeSendReturns
+	return fakeReturns.result1
+}
+
+func (fake *ClientStream) CloseSendCallCount() int {
+	fake.closeSendMutex.RLock()
+	defer fake.closeSendMutex.RUnlock()
+	return len(fake.closeSendArgsForCall)
+}
+
+func (fake *ClientStream) CloseSendCalls(stub func() error) {
+	fake.closeSendMutex.Lock()
+	defer fake.closeSendMutex.Unlock()
+	fake.CloseSendStub = stub
+}
+
+func (fake *ClientStream) CloseSendReturns(result1 error) {
+	fake.closeSendMutex.Lock()
+	defer fake.closeSendMutex.Unlock()
+	fake.CloseSendStub = nil
+	fake.closeSendReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ClientStream) CloseSendReturnsOnCall(i int, result1 error) {
+	fake.closeSendMutex.Lock()
+	defer fake.closeSendMutex.Unlock()
+	fake.CloseSendStub = nil
+	if fake.closeSendReturnsOnCall == nil {
+		fake.closeSendReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.closeSendReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ClientStream) Recv() (*peer.ChaincodeMessage, error) {
 	fake.recvMutex.Lock()
 	ret, specificReturn := fake.recvReturnsOnCall[len(fake.recvArgsForCall)]
 	fake.recvArgsForCall = append(fake.recvArgsForCall, struct {
@@ -52,19 +114,19 @@ func (fake *PeerChaincodeStream) Recv() (*peer.ChaincodeMessage, error) {
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *PeerChaincodeStream) RecvCallCount() int {
+func (fake *ClientStream) RecvCallCount() int {
 	fake.recvMutex.RLock()
 	defer fake.recvMutex.RUnlock()
 	return len(fake.recvArgsForCall)
 }
 
-func (fake *PeerChaincodeStream) RecvCalls(stub func() (*peer.ChaincodeMessage, error)) {
+func (fake *ClientStream) RecvCalls(stub func() (*peer.ChaincodeMessage, error)) {
 	fake.recvMutex.Lock()
 	defer fake.recvMutex.Unlock()
 	fake.RecvStub = stub
 }
 
-func (fake *PeerChaincodeStream) RecvReturns(result1 *peer.ChaincodeMessage, result2 error) {
+func (fake *ClientStream) RecvReturns(result1 *peer.ChaincodeMessage, result2 error) {
 	fake.recvMutex.Lock()
 	defer fake.recvMutex.Unlock()
 	fake.RecvStub = nil
@@ -74,7 +136,7 @@ func (fake *PeerChaincodeStream) RecvReturns(result1 *peer.ChaincodeMessage, res
 	}{result1, result2}
 }
 
-func (fake *PeerChaincodeStream) RecvReturnsOnCall(i int, result1 *peer.ChaincodeMessage, result2 error) {
+func (fake *ClientStream) RecvReturnsOnCall(i int, result1 *peer.ChaincodeMessage, result2 error) {
 	fake.recvMutex.Lock()
 	defer fake.recvMutex.Unlock()
 	fake.RecvStub = nil
@@ -90,7 +152,7 @@ func (fake *PeerChaincodeStream) RecvReturnsOnCall(i int, result1 *peer.Chaincod
 	}{result1, result2}
 }
 
-func (fake *PeerChaincodeStream) Send(arg1 *peer.ChaincodeMessage) error {
+func (fake *ClientStream) Send(arg1 *peer.ChaincodeMessage) error {
 	fake.sendMutex.Lock()
 	ret, specificReturn := fake.sendReturnsOnCall[len(fake.sendArgsForCall)]
 	fake.sendArgsForCall = append(fake.sendArgsForCall, struct {
@@ -108,26 +170,26 @@ func (fake *PeerChaincodeStream) Send(arg1 *peer.ChaincodeMessage) error {
 	return fakeReturns.result1
 }
 
-func (fake *PeerChaincodeStream) SendCallCount() int {
+func (fake *ClientStream) SendCallCount() int {
 	fake.sendMutex.RLock()
 	defer fake.sendMutex.RUnlock()
 	return len(fake.sendArgsForCall)
 }
 
-func (fake *PeerChaincodeStream) SendCalls(stub func(*peer.ChaincodeMessage) error) {
+func (fake *ClientStream) SendCalls(stub func(*peer.ChaincodeMessage) error) {
 	fake.sendMutex.Lock()
 	defer fake.sendMutex.Unlock()
 	fake.SendStub = stub
 }
 
-func (fake *PeerChaincodeStream) SendArgsForCall(i int) *peer.ChaincodeMessage {
+func (fake *ClientStream) SendArgsForCall(i int) *peer.ChaincodeMessage {
 	fake.sendMutex.RLock()
 	defer fake.sendMutex.RUnlock()
 	argsForCall := fake.sendArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *PeerChaincodeStream) SendReturns(result1 error) {
+func (fake *ClientStream) SendReturns(result1 error) {
 	fake.sendMutex.Lock()
 	defer fake.sendMutex.Unlock()
 	fake.SendStub = nil
@@ -136,7 +198,7 @@ func (fake *PeerChaincodeStream) SendReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *PeerChaincodeStream) SendReturnsOnCall(i int, result1 error) {
+func (fake *ClientStream) SendReturnsOnCall(i int, result1 error) {
 	fake.sendMutex.Lock()
 	defer fake.sendMutex.Unlock()
 	fake.SendStub = nil
@@ -150,9 +212,11 @@ func (fake *PeerChaincodeStream) SendReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *PeerChaincodeStream) Invocations() map[string][][]interface{} {
+func (fake *ClientStream) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.closeSendMutex.RLock()
+	defer fake.closeSendMutex.RUnlock()
 	fake.recvMutex.RLock()
 	defer fake.recvMutex.RUnlock()
 	fake.sendMutex.RLock()
@@ -164,7 +228,7 @@ func (fake *PeerChaincodeStream) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *PeerChaincodeStream) recordInvocation(key string, args []interface{}) {
+func (fake *ClientStream) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {

--- a/shim/internal/server.go
+++ b/shim/internal/server.go
@@ -1,0 +1,95 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+const (
+	serverInterval    = time.Duration(2) * time.Hour    // 2 hours - gRPC default
+	serverTimeout     = time.Duration(20) * time.Second // 20 sec - gRPC default
+	serverMinInterval = time.Duration(1) * time.Minute
+	connectionTimeout = 5 * time.Second
+)
+
+type Server struct {
+	Listener net.Listener
+	Server   *grpc.Server
+}
+
+func (s *Server) Start() error {
+	if s.Listener == nil {
+		return errors.New("nil listener")
+	}
+
+	if s.Server == nil {
+		return errors.New("nil server")
+	}
+
+	return s.Server.Serve(s.Listener)
+}
+
+func (s *Server) Stop() {
+	if s.Server != nil {
+		s.Server.Stop()
+	}
+}
+
+// NewServer creates a new implementation of a GRPC Server given a
+// listen address
+func NewServer(address string, tlsConf *tls.Config) (*Server, error) {
+	if address == "" {
+		return nil, errors.New("server listen address not provided")
+	}
+
+	//create our listener
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+
+	//set up our server options
+	var serverOpts []grpc.ServerOption
+
+	if tlsConf != nil {
+		//TODO FAB-16690 - add TLS support
+	}
+
+	// Default properties follow - let's start simple and stick with defaults for now.
+	// These match Fabric peer side properties. We can expose these as user properties
+	// if needed
+
+	// set max send and recv msg sizes
+	serverOpts = append(serverOpts, grpc.MaxSendMsgSize(maxSendMessageSize))
+	serverOpts = append(serverOpts, grpc.MaxRecvMsgSize(maxRecvMessageSize))
+
+	//set keepalive
+	kap := keepalive.ServerParameters{
+		Time:    serverInterval,
+		Timeout: serverTimeout,
+	}
+	serverOpts = append(serverOpts, grpc.KeepaliveParams(kap))
+
+	//set enforcement policy
+	kep := keepalive.EnforcementPolicy{
+		MinTime: serverMinInterval,
+		// allow keepalive w/o rpc
+		PermitWithoutStream: true,
+	}
+	serverOpts = append(serverOpts, grpc.KeepaliveEnforcementPolicy(kep))
+
+	//set default connection timeout
+	serverOpts = append(serverOpts, grpc.ConnectionTimeout(connectionTimeout))
+
+	server := grpc.NewServer(serverOpts...)
+
+	return &Server{Listener: listener, Server: server}, nil
+}

--- a/shim/internal/server_test.go
+++ b/shim/internal/server_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright State Street Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package internal_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim/internal"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBadServer(t *testing.T) {
+	srv := &internal.Server{}
+	err := srv.Start()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "nil listener")
+
+	l, err := net.Listen("tcp", ":0")
+	assert.NotNil(t, l)
+	assert.Nil(t, err)
+	srv = &internal.Server{Listener: l}
+	err = srv.Start()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "nil server")
+}
+
+func TestServerAddressNotProvided(t *testing.T) {
+	srv, err := internal.NewServer("", nil)
+	assert.Nil(t, srv)
+	assert.NotNil(t, err, "server listen address not provided")
+}
+
+func TestBadServerAddress(t *testing.T) {
+	srv, err := internal.NewServer("__badhost__:0", nil)
+	assert.Nil(t, srv)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "listen tcp: lookup __badhost__")
+
+	srv, err = internal.NewServer("host", nil)
+	assert.Nil(t, srv)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "listen tcp: address host: missing port in address")
+}

--- a/shim/internal/server_test.go
+++ b/shim/internal/server_test.go
@@ -9,10 +9,12 @@ package internal_test
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/hyperledger/fabric-chaincode-go/shim/internal"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/keepalive"
 )
 
 func TestBadServer(t *testing.T) {
@@ -31,18 +33,26 @@ func TestBadServer(t *testing.T) {
 }
 
 func TestServerAddressNotProvided(t *testing.T) {
-	srv, err := internal.NewServer("", nil)
+	kaOpts := &keepalive.ServerParameters{
+		Time:    1 * time.Minute,
+		Timeout: 20 * time.Second,
+	}
+	srv, err := internal.NewServer("", nil, kaOpts)
 	assert.Nil(t, srv)
 	assert.NotNil(t, err, "server listen address not provided")
 }
 
 func TestBadServerAddress(t *testing.T) {
-	srv, err := internal.NewServer("__badhost__:0", nil)
+	kaOpts := &keepalive.ServerParameters{
+		Time:    1 * time.Minute,
+		Timeout: 20 * time.Second,
+	}
+	srv, err := internal.NewServer("__badhost__:0", nil, kaOpts)
 	assert.Nil(t, srv)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "listen tcp: lookup __badhost__")
 
-	srv, err = internal.NewServer("host", nil)
+	srv, err = internal.NewServer("host", nil, kaOpts)
 	assert.Nil(t, srv)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "listen tcp: address host: missing port in address")

--- a/shim/shim.go
+++ b/shim/shim.go
@@ -25,6 +25,7 @@ const (
 	emptyKeySubstitute    = "\x01"
 )
 
+// peer as server
 var peerAddress = flag.String("peer.address", "", "peer address")
 
 //this separates the chaincode stream interface establishment

--- a/shim/shim.go
+++ b/shim/shim.go
@@ -29,13 +29,13 @@ var peerAddress = flag.String("peer.address", "", "peer address")
 
 //this separates the chaincode stream interface establishment
 //so we can replace it with a mock peer stream
-type peerStreamGetter func(name string) (PeerChaincodeStream, error)
+type peerStreamGetter func(name string) (ClientStream, error)
 
 //UTs to setup mock peer stream getter
 var streamGetter peerStreamGetter
 
 //the non-mock user CC stream establishment func
-func userChaincodeStreamGetter(name string) (PeerChaincodeStream, error) {
+func userChaincodeStreamGetter(name string) (ClientStream, error) {
 	if *peerAddress == "" {
 		return nil, errors.New("flag 'peer.address' must be set")
 	}
@@ -71,21 +71,27 @@ func Start(cc Chaincode) error {
 		return err
 	}
 
-	err = chatWithPeer(chaincodename, stream, cc)
+	err = chaincodeAsClientChat(chaincodename, stream, cc)
 
 	return err
 }
 
 // StartInProc is an entry point for system chaincodes bootstrap. It is not an
 // API for chaincodes.
-func StartInProc(chaincodename string, stream PeerChaincodeStream, cc Chaincode) error {
+func StartInProc(chaincodename string, stream ClientStream, cc Chaincode) error {
+	return chaincodeAsClientChat(chaincodename, stream, cc)
+}
+
+// this is the chat stream resulting from the chaincode-as-client model where the chaincode initiates connection
+func chaincodeAsClientChat(chaincodename string, stream ClientStream, cc Chaincode) error {
+	defer stream.CloseSend()
 	return chatWithPeer(chaincodename, stream, cc)
 }
 
+// chat stream for peer-chaincode interactions post connection
 func chatWithPeer(chaincodename string, stream PeerChaincodeStream, cc Chaincode) error {
 	// Create the shim handler responsible for all control logic
 	handler := newChaincodeHandler(stream, cc)
-	defer stream.CloseSend()
 
 	// Send the ChaincodeID during register.
 	chaincodeID := &peerpb.ChaincodeID{Name: chaincodename}

--- a/shim/shim_test.go
+++ b/shim/shim_test.go
@@ -146,27 +146,38 @@ func TestChaincodeServerStart(t *testing.T) {
 		{
 			name:        "Missing Chaincode ID",
 			ccsrv:       ChaincodeServer{},
-			expectedErr: "name must be specified",
+			expectedErr: "ccid must be specified",
 		},
 		{
 			name:        "Missing Peer Address",
-			ccsrv:       ChaincodeServer{Name: "cc"},
+			ccsrv:       ChaincodeServer{CCID: "cc"},
 			expectedErr: "address must be specified",
 		},
 		{
 			name:        "Missing Peer Address and Chaincode Address",
-			ccsrv:       ChaincodeServer{Name: "cc", Address: "127.0.0.1:12345"},
+			ccsrv:       ChaincodeServer{CCID: "cc", Address: "127.0.0.1:12345"},
 			expectedErr: "chaincode must be specified",
 		},
 		{
 			name:        "Badly formed chaincode server address",
-			ccsrv:       ChaincodeServer{Name: "cc", Address: "127.0.0.1", CC: &mockChaincode{}},
+			ccsrv:       ChaincodeServer{CCID: "cc", Address: "127.0.0.1", CC: &mockChaincode{}, TLSProps: TLSProperties{Disabled: true}},
 			expectedErr: "listen tcp: address 127.0.0.1: missing port in address",
 		},
 		{
 			name:        "Bad host in chaincode server address",
-			ccsrv:       ChaincodeServer{Name: "cc", Address: "__badhost__:12345", CC: &mockChaincode{}},
+			ccsrv:       ChaincodeServer{CCID: "cc", Address: "__badhost__:12345", CC: &mockChaincode{}, TLSProps: TLSProperties{Disabled: true}},
 			containsErr: "listen tcp: lookup __badhost__",
+		},
+		// Basic TLS tests, path tests
+		{
+			name:        "TLS enabled but key path not provided",
+			ccsrv:       ChaincodeServer{CCID: "cc", Address: "host:12345", CC: &mockChaincode{}, TLSProps: TLSProperties{Disabled: false}},
+			containsErr: "key not provided",
+		},
+		{
+			name:        "TLS enabled but cert path not provided",
+			ccsrv:       ChaincodeServer{CCID: "cc", Address: "host:12345", CC: &mockChaincode{}, TLSProps: TLSProperties{Disabled: false, Key: []byte("key")}},
+			containsErr: "cert not provided",
 		},
 	}
 

--- a/shim/shim_test.go
+++ b/shim/shim_test.go
@@ -21,7 +21,7 @@ func TestStart(t *testing.T) {
 		name         string
 		envVars      map[string]string
 		peerAddress  string
-		streamGetter func(name string) (PeerChaincodeStream, error)
+		streamGetter func(name string) (ClientStream, error)
 		cc           Chaincode
 		expectedErr  string
 	}{
@@ -60,8 +60,8 @@ func TestStart(t *testing.T) {
 				"CORE_PEER_TLS_ENABLED":  "false",
 			},
 			peerAddress: "127.0.0.1:12345",
-			streamGetter: func(name string) (PeerChaincodeStream, error) {
-				stream := &mock.PeerChaincodeStream{}
+			streamGetter: func(name string) (ClientStream, error) {
+				stream := &mock.ClientStream{}
 				return stream, nil
 			},
 			expectedErr: "received nil message, ending chaincode stream",
@@ -73,8 +73,8 @@ func TestStart(t *testing.T) {
 				"CORE_PEER_TLS_ENABLED":  "false",
 			},
 			peerAddress: "127.0.0.1:12345",
-			streamGetter: func(name string) (PeerChaincodeStream, error) {
-				stream := &mock.PeerChaincodeStream{}
+			streamGetter: func(name string) (ClientStream, error) {
+				stream := &mock.ClientStream{}
 				stream.RecvReturns(nil, io.EOF)
 				return stream, nil
 			},
@@ -87,8 +87,8 @@ func TestStart(t *testing.T) {
 				"CORE_PEER_TLS_ENABLED":  "false",
 			},
 			peerAddress: "127.0.0.1:12345",
-			streamGetter: func(name string) (PeerChaincodeStream, error) {
-				stream := &mock.PeerChaincodeStream{}
+			streamGetter: func(name string) (ClientStream, error) {
+				stream := &mock.ClientStream{}
 				stream.RecvReturns(nil, errors.New("recvError"))
 				return stream, nil
 			},
@@ -101,8 +101,8 @@ func TestStart(t *testing.T) {
 				"CORE_PEER_TLS_ENABLED":  "false",
 			},
 			peerAddress: "127.0.0.1:12345",
-			streamGetter: func(name string) (PeerChaincodeStream, error) {
-				stream := &mock.PeerChaincodeStream{}
+			streamGetter: func(name string) (ClientStream, error) {
+				stream := &mock.ClientStream{}
 				stream.RecvReturnsOnCall(
 					0,
 					&peerpb.ChaincodeMessage{


### PR DESCRIPTION
Chaincode-as-server shim implementation for go chaincodes

* Creates chaincode server using the "Chaincode" proto service
* exposes ChaincodeServer api for running chaincodes
* hooks it up with post-connection stream processing (adjusts shim.go to handle either flow)
* For TLS, follows Peer's implementation for most part
`NOTE: latest fabric master was built and unit-tested by replacing vendored code with these changes.`