### PR TITLE
FAB-16723 Fix a few stale references to protos

### DIFF
--- a/shim/interfaces.go
+++ b/shim/interfaces.go
@@ -46,14 +46,15 @@ type ChaincodeStubInterface interface {
 	GetArgsSlice() ([]byte, error)
 
 	// GetTxID returns the tx_id of the transaction proposal, which is unique per
-	// transaction and per client. See ChannelHeader in protos/common/common.proto
+	// transaction and per client. See
+	// https://godoc.org/github.com/hyperledger/fabric-protos-go/common#ChannelHeader
 	// for further details.
 	GetTxID() string
 
 	// GetChannelID returns the channel the proposal is sent to for chaincode to process.
-	// This would be the channel_id of the transaction proposal (see ChannelHeader
-	// in protos/common/common.proto) except where the chaincode is calling another on
-	// a different channel
+	// This would be the channel_id of the transaction proposal (see
+	// https://godoc.org/github.com/hyperledger/fabric-protos-go/common#ChannelHeader )
+	// except where the chaincode is calling another on a different channel.
 	GetChannelID() string
 
 	// InvokeChaincode locally calls the specified chaincode `Invoke` using the


### PR DESCRIPTION
The golang protos were moved from fabric/protos to fabric-protos-go and
the chaincode golang shim to fabric-chaincode-go, so the relative
protos/common/common.proto references no longer make any sense.  This
simply replaces those relative references with links to the godoc.

Signed-off-by: Jason Yellick <jyellick@us.ibm.com>