### PR TITLE
HasOUValue function for cid library

### DIFF
--- a/pkg/cid/README.md
+++ b/pkg/cid/README.md
@@ -3,50 +3,53 @@
 The client identity chaincode library enables you to write chaincode which
 makes access control decisions based on the identity of the client
 (i.e. the invoker of the chaincode).  In particular, you may make access
-control decisions based on either or both of the following associated with
+control decisions based on any or a combination of the following information associated with
 the client:
 
 * the client identity's MSP (Membership Service Provider) ID
 * an attribute associated with the client identity
+* an OU (Organizational Unit) value associated with the client identity
 
 Attributes are simply name and value pairs associated with an identity.
 For example, `email=me@gmail.com` indicates an identity has the `email`
 attribute with a value of `me@gmail.com`.
-
 
 ## Using the client identity chaincode library
 
 This section describes how to use the client identity chaincode library.
 
 All code samples below assume two things:
+
 1. The type of the `stub` variable is `ChaincodeStubInterface` as passed
    to your chaincode.
 2. You have added the following import statement to your chaincode.
-    ```
+
+    ```golang
     import "github.com/hyperledger/fabric-chaincode-go/shim/pkg/cid"
     ```
-#### Getting the client's ID
+
+### Getting the client's ID
 
 The following demonstrates how to get an ID for the client which is guaranteed
 to be unique within the MSP:
 
-```
+```golang
 id, err := cid.GetID(stub)
 ```
 
-#### Getting the MSP ID
+### Getting the MSP ID
 
 The following demonstrates how to get the MSP ID of the client's identity:
 
-```
+```golang
 mspid, err := cid.GetMSPID(stub)
 ```
 
-#### Getting an attribute value
+### Getting an attribute value
 
 The following demonstrates how to get the value of the *attr1* attribute:
 
-```
+```golang
 val, ok, err := cid.GetAttributeValue(stub, "attr1")
 if err != nil {
    // There was an error trying to retrieve the attribute
@@ -57,14 +60,14 @@ if !ok {
 // Do something with the value of 'val'
 ```
 
-#### Asserting an attribute value
+### Asserting an attribute value
 
 Often all you want to do is to make an access control decision based on the value
 of an attribute, i.e. to assert the value of an attribute.  For example, the following
 will return an error if the client does not have the `myapp.admin` attribute
 with a value of `true`:
 
-```
+```golang
 err := cid.AssertAttributeValue(stub, "myapp.admin", "true")
 if err != nil {
    // Return an error
@@ -74,26 +77,39 @@ if err != nil {
 This is effectively using attributes to implement role-based access control,
 or RBAC for short.
 
-#### Getting the client's X509 certificate
+### Checking for a specific OU value
+
+```golang
+found, err := cid.HasOUValue(stub, "myapp.admin")
+if err != nil {
+   // Return an error
+}
+if !found {
+   // The client identity is not part of the Organizational Unit
+   // Return an error
+}
+```
+
+### Getting the client's X509 certificate
 
 The following demonstrates how to get the X509 certificate of the client, or
 nil if the client's identity was not based on an X509 certificate:
 
-```
+```golang
 cert, err := cid.GetX509Certificate(stub)
 ```
 
 Note that both `cert` and `err` may be nil as will be the case if the identity
 is not using an X509 certificate.
 
-#### Performing multiple operations more efficiently
+### Performing multiple operations more efficiently
 
 Sometimes you may need to perform multiple operations in order to make an access
 decision.  For example, the following demonstrates how to grant access to
 identities with MSP *org1MSP* and *attr1* OR with MSP *org1MSP* and *attr2*.
 
-```
-// Get the client ID object
+```golang
+// Get the Client ID object
 id, err := cid.New(stub)
 if err != nil {
    // Handle error
@@ -111,8 +127,9 @@ switch mspid {
       err = errors.New("Wrong MSP")
 }
 ```
+
 Although it is not required, it is more efficient to make the `cid.New` call
-to get the ClientIdentity object if you need to perform multiple operations,
+to get the ClientID object if you need to perform multiple operations,
 as demonstrated above.
 
 ## Adding Attributes to Identities
@@ -120,7 +137,7 @@ as demonstrated above.
 This section describes how to add custom attributes to certificates when
 using Hyperledger Fabric CA as well as when using an external CA.
 
-#### Managing attributes with Fabric CA
+### Managing attributes with Fabric CA
 
 There are two methods of adding attributes to an enrollment certificate
 with fabric-ca:
@@ -137,7 +154,7 @@ with fabric-ca:
      enrollment certificate by default.  The *email* attribute is not added
      to the enrollment certificate by default.
 
-     ```
+     ```bash
      fabric-ca-client register --id.name user1 --id.secret user1pw --id.type user --id.affiliation org1 --id.attrs 'app1Admin=true:ecert,email=user1@gmail.com'
      ```
 
@@ -150,9 +167,11 @@ with fabric-ca:
      The following shows how to enroll *user1* with the *email* attribute,
      without the *app1Admin* attribute and optionally with the *phone* attribute
      (if the user possesses *phone* attribute).
-     ```
+
+     ```bash
      fabric-ca-client enroll -u http://user1:user1pw@localhost:7054 --enrollment.attrs "email,phone:opt"
      ```
+
 #### Attribute format in a certificate
 
 Attributes are stored inside an X509 certificate as an extension with an
@@ -212,3 +231,5 @@ then you must ensure that the certificates which are issued by your external CA
 contain attributes of the form shown above.  In particular, the certificates
 must contain the `1.2.3.4.5.6.7.8.1` X509v3 extension with a JSON value
 containing the attribute names and values for the identity.
+
+If your external CA does not support extensions with an unknown OID like `1.2.3.4.5.6.7.8.1`, the OU fields of the certificate subject's DN can be used as an alternative to the attributes and the HasOUValue function of the cid library can be used in the chaincode to control access.

--- a/pkg/cid/cid.go
+++ b/pkg/cid/cid.go
@@ -55,6 +55,15 @@ func AssertAttributeValue(stub ChaincodeStubInterface, attrName, attrValue strin
 	return c.AssertAttributeValue(attrName, attrValue)
 }
 
+// HasOUValue checks if an OU with the specified value is present
+func HasOUValue(stub ChaincodeStubInterface, OUValue string) (bool, error) {
+	c, err := New(stub)
+	if err != nil {
+		return false, err
+	}
+	return c.HasOUValue(OUValue)
+}
+
 // GetX509Certificate returns the X509 certificate associated with the client,
 // or nil if it was not identified by an X509 certificate.
 func GetX509Certificate(stub ChaincodeStubInterface) (*x509.Certificate, error) {
@@ -65,17 +74,17 @@ func GetX509Certificate(stub ChaincodeStubInterface) (*x509.Certificate, error) 
 	return c.GetX509Certificate()
 }
 
-// ClientIdentityImpl implements the ClientIdentity interface
-type clientIdentityImpl struct {
+// ClientID holds the information of the transaction creator.
+type ClientID struct {
 	stub  ChaincodeStubInterface
 	mspID string
 	cert  *x509.Certificate
 	attrs *attrmgr.Attributes
 }
 
-// New returns an instance of ClientIdentity
-func New(stub ChaincodeStubInterface) (ClientIdentity, error) {
-	c := &clientIdentityImpl{stub: stub}
+// New returns an instance of ClientID
+func New(stub ChaincodeStubInterface) (*ClientID, error) {
+	c := &ClientID{stub: stub}
 	err := c.init()
 	if err != nil {
 		return nil, err
@@ -84,7 +93,7 @@ func New(stub ChaincodeStubInterface) (ClientIdentity, error) {
 }
 
 // GetID returns a unique ID associated with the invoking identity.
-func (c *clientIdentityImpl) GetID() (string, error) {
+func (c *ClientID) GetID() (string, error) {
 	// When IdeMix, c.cert is nil for x509 type
 	// Here will return "", as there is no x509 type cert for generate id value with logic below.
 	if c.cert == nil {
@@ -99,12 +108,12 @@ func (c *clientIdentityImpl) GetID() (string, error) {
 
 // GetMSPID returns the ID of the MSP associated with the identity that
 // submitted the transaction
-func (c *clientIdentityImpl) GetMSPID() (string, error) {
+func (c *ClientID) GetMSPID() (string, error) {
 	return c.mspID, nil
 }
 
 // GetAttributeValue returns value of the specified attribute
-func (c *clientIdentityImpl) GetAttributeValue(attrName string) (value string, found bool, err error) {
+func (c *ClientID) GetAttributeValue(attrName string) (value string, found bool, err error) {
 	if c.attrs == nil {
 		return "", false, nil
 	}
@@ -112,7 +121,7 @@ func (c *clientIdentityImpl) GetAttributeValue(attrName string) (value string, f
 }
 
 // AssertAttributeValue checks to see if an attribute value equals the specified value
-func (c *clientIdentityImpl) AssertAttributeValue(attrName, attrValue string) error {
+func (c *ClientID) AssertAttributeValue(attrName, attrValue string) error {
 	val, ok, err := c.GetAttributeValue(attrName)
 	if err != nil {
 		return err
@@ -126,14 +135,30 @@ func (c *clientIdentityImpl) AssertAttributeValue(attrName, attrValue string) er
 	return nil
 }
 
+// HasOUValue checks if an OU with the specified value is present
+func (c *ClientID) HasOUValue(OUValue string) (bool, error) {
+	x509Cert := c.cert
+	if x509Cert == nil {
+		// Here it will return false and an error, as there is no x509 type cert to check for OU values.
+		return false, fmt.Errorf("cannot obtain an X509 certificate for the identity")
+	}
+
+	for _, OU := range x509Cert.Subject.OrganizationalUnit {
+		if OU == OUValue {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // GetX509Certificate returns the X509 certificate associated with the client,
 // or nil if it was not identified by an X509 certificate.
-func (c *clientIdentityImpl) GetX509Certificate() (*x509.Certificate, error) {
+func (c *ClientID) GetX509Certificate() (*x509.Certificate, error) {
 	return c.cert, nil
 }
 
 // Initialize the client
-func (c *clientIdentityImpl) init() error {
+func (c *ClientID) init() error {
 	signingID, err := c.getIdentity()
 	if err != nil {
 		return err
@@ -163,7 +188,7 @@ func (c *clientIdentityImpl) init() error {
 
 // Unmarshals the bytes returned by ChaincodeStubInterface.GetCreator method and
 // returns the resulting msp.SerializedIdentity object
-func (c *clientIdentityImpl) getIdentity() (*msp.SerializedIdentity, error) {
+func (c *ClientID) getIdentity() (*msp.SerializedIdentity, error) {
 	sid := &msp.SerializedIdentity{}
 	creator, err := c.stub.GetCreator()
 	if err != nil || creator == nil {
@@ -176,7 +201,7 @@ func (c *clientIdentityImpl) getIdentity() (*msp.SerializedIdentity, error) {
 	return sid, nil
 }
 
-func (c *clientIdentityImpl) getAttributesFromIdemix() error {
+func (c *ClientID) getAttributesFromIdemix() error {
 	creator, err := c.stub.GetCreator()
 	attrs, err := attrmgr.New().GetAttributesFromIdemix(creator)
 	if err != nil {

--- a/pkg/cid/cid_test.go
+++ b/pkg/cid/cid_test.go
@@ -66,6 +66,11 @@ func TestClient(t *testing.T) {
 	assert.False(t, found, "Attribute 'foo' should not be found in the submitter cert")
 	err = cid.AssertAttributeValue(stub, "foo", "")
 	assert.Error(t, err, "AssertAttributeValue should have returned an error with no attribute")
+	found, err = cid.HasOUValue(stub, "Fabric")
+	assert.NoError(t, err, "Error getting X509 cert of the submitter of the transaction")
+	assert.True(t, found)
+	found, err = cid.HasOUValue(stub, "foo")
+	assert.False(t, found, "OU 'foo' should not be found in the submitter cert")
 
 	stub, err = getMockStubWithAttrs()
 	assert.NoError(t, err, "Failed to get mock submitter")
@@ -83,6 +88,8 @@ func TestClient(t *testing.T) {
 	assert.NoError(t, err, "Error in AssertAttributeValue")
 	err = cid.AssertAttributeValue(stub, "attr1", "val2")
 	assert.Error(t, err, "Assert should have failed; value was val1, not val2")
+	found, err = cid.HasOUValue(stub, "foo")
+	assert.NoError(t, err, "Error getting X509 cert of the submitter of the transaction")
 
 	// Error case1
 	stub, err = getMockStubWithNilCreator()


### PR DESCRIPTION
Added HasOUValue func to ClientIdentity that checks if an OU with a specified value is present in the client's X509 cert.

This way granular access control in the chaincode can also be done based on OU values instead of only on attributes from the custom extra extension in the cert that is not supported by external CA services.
Link to JIRA item FABCG-12: https://jira.hyperledger.org/browse/FABCG-12