### PR TITLE
Revert "TLS Client auth not working for chaincode server"

### DIFF
--- a/shim/internal/config.go
+++ b/shim/internal/config.go
@@ -127,7 +127,7 @@ func LoadTLSConfig(isserver bool, key, cert, root []byte) (*tls.Config, error) {
 	tlscfg := &tls.Config{
 		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cccert},
-		ClientCAs:    rootCertPool,
+		RootCAs:      rootCertPool,
 	}
 
 	//follow Peer's server default config properties


### PR DESCRIPTION
This change removes ClientCAs from the TLS config and, as such, breaks chaincode as client flows. We discovered this when bumping our chaincode dependency caused most of the integration tests to fail.

Since this repo now hosts an active module, we are reverting this to prevent users from encountering further issues.

Reverts hyperledger/fabric-chaincode-go#15