### PR TITLE
[FABCG-13] Support new API for retrieving MSPID via the CORE_PEER_LOCALMSPID env var

### DIFF
--- a/shim/stub.go
+++ b/shim/stub.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"os"
 	"unicode/utf8"
 
 	"github.com/golang/protobuf/proto"
@@ -130,6 +131,18 @@ func (s *ChaincodeStub) GetChannelID() string {
 // GetDecorations ...
 func (s *ChaincodeStub) GetDecorations() map[string][]byte {
 	return s.decorations
+}
+
+// GetMSPID returns the local mspid of the peer by checking the CORE_PEER_LOCALMSPID
+// env var and returns an error if the env var is not set
+func GetMSPID() (string, error) {
+	mspid := os.Getenv("CORE_PEER_LOCALMSPID")
+
+	if mspid == "" {
+		return "", errors.New("'CORE_PEER_LOCALMSPID' is not set")
+	}
+
+	return mspid, nil
 }
 
 // ------------- Call Chaincode functions ---------------

--- a/shim/stub_test.go
+++ b/shim/stub_test.go
@@ -6,6 +6,7 @@ package shim
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"os"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -233,6 +234,19 @@ func TestChaincodeStubGetTxTimestamp(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, proto.Equal(ts, tt.ts))
 	}
+}
+
+func TestGetMSPID(t *testing.T) {
+	_, err := GetMSPID()
+	assert.EqualError(t, err, "'CORE_PEER_LOCALMSPID' is not set")
+
+	os.Setenv("CORE_PEER_LOCALMSPID", "mspid")
+
+	mspid, err := GetMSPID()
+	assert.NoError(t, err)
+	assert.Equal(t, "mspid", mspid)
+
+	os.Unsetenv("CORE_PEER_LOCALMSPID")
 }
 
 func TestChaincodeStubHandlers(t *testing.T) {


### PR DESCRIPTION
[FABCG-13](https://jira.hyperledger.org/browse/FABCG-13)