### PR TITLE
Fixed import in the README.md file

### DIFF
--- a/pkg/cid/README.md
+++ b/pkg/cid/README.md
@@ -25,7 +25,7 @@ All code samples below assume two things:
 2. You have added the following import statement to your chaincode.
 
     ```golang
-    import "github.com/hyperledger/fabric-chaincode-go/shim/pkg/cid"
+    import "github.com/hyperledger/fabric-chaincode-go/pkg/cid"
     ```
 
 ### Getting the client's ID


### PR DESCRIPTION
The import seems to be incorrect since the `pkg` directory is not a sub-directory of `shim` (anymore?).