### PR TITLE
Use fabric-core-maintainers group in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Fabric Maintainers
-*	@ale-linux @binhn @c0rwin @christo4ferris @denyeart @guoger @JonathanLevi @jyellick @kchristidis @manish-sethi @mastersingh24 @muralisrini @sykesm @yacovm
+*       @hyperledger/fabric-core-maintainers


### PR DESCRIPTION
Be a bit more consistent with hyperledger/fabric and hyperledger/fabric-protos