### PR TITLE
Clarify GetHistoryForKey results ordering

### DIFF
--- a/shim/interfaces.go
+++ b/shim/interfaces.go
@@ -229,6 +229,11 @@ type ChaincodeStubInterface interface {
 	// detected at validation/commit time. Applications susceptible to this
 	// should therefore not use GetHistoryForKey as part of transactions that
 	// update ledger, and should limit use to read-only chaincode operations.
+	// Starting in Fabric v2.0, the GetHistoryForKey chaincode API
+	// will return results from newest to oldest in terms of ordered transaction
+	// height (block height and transaction height within block).
+	// This will allow applications to efficiently iterate through the top results
+	// to understand recent changes to a key.
 	GetHistoryForKey(key string) (HistoryQueryIteratorInterface, error)
 
 	// GetPrivateData returns the value of the specified `key` from the specified


### PR DESCRIPTION
Clarify that GetHistoryForKey() sorts results from latest to oldest,
as mentioned in the v2.0.0 release notes.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>