### PR TITLE
 Updated documentation for getStateByPartialCompositeKey

### DIFF
--- a/shim/interfaces.go
+++ b/shim/interfaces.go
@@ -147,7 +147,9 @@ type ChaincodeStubInterface interface {
 	// See related functions SplitCompositeKey and CreateCompositeKey.
 	// Call Close() on the returned StateQueryIteratorInterface object when done.
 	// The query is re-executed during validation phase to ensure result set
-	// has not changed since transaction endorsement (phantom reads detected).
+	// has not changed since transaction endorsement (phantom reads detected). This function should be used only for
+	// a partial composite key. For a full composite key, an iter with empty response
+	// would be returned.
 	GetStateByPartialCompositeKey(objectType string, keys []string) (StateQueryIteratorInterface, error)
 
 	// GetStateByPartialCompositeKeyWithPagination queries the state in the ledger based on
@@ -167,7 +169,9 @@ type ChaincodeStubInterface interface {
 	// and should not contain U+0000 (nil byte) and U+10FFFF (biggest and unallocated
 	// code point). See related functions SplitCompositeKey and CreateCompositeKey.
 	// Call Close() on the returned StateQueryIteratorInterface object when done.
-	// This call is only supported in a read only transaction.
+	// This call is only supported in a read only transaction. This function should be used only for
+	// a partial composite key. For a full composite key, an iter with empty response
+	// would be returned.
 	GetStateByPartialCompositeKeyWithPagination(objectType string, keys []string,
 		pageSize int32, bookmark string) (StateQueryIteratorInterface, *pb.QueryResponseMetadata, error)
 
@@ -297,7 +301,9 @@ type ChaincodeStubInterface interface {
 	// See related functions SplitCompositeKey and CreateCompositeKey.
 	// Call Close() on the returned StateQueryIteratorInterface object when done.
 	// The query is re-executed during validation phase to ensure result set
-	// has not changed since transaction endorsement (phantom reads detected).
+	// has not changed since transaction endorsement (phantom reads detected). This function should be used only for
+	//a partial composite key. For a full composite key, an iter with empty response
+	//would be returned.
 	GetPrivateDataByPartialCompositeKey(collection, objectType string, keys []string) (StateQueryIteratorInterface, error)
 
 	// GetPrivateDataQueryResult performs a "rich" query against a given private

--- a/shim/stub.go
+++ b/shim/stub.go
@@ -496,12 +496,7 @@ func validateSimpleKeys(simpleKeys ...string) error {
 	return nil
 }
 
-//GetStateByPartialCompositeKey function can be invoked by a chaincode to query the
-//state based on a given partial composite key. This function returns an
-//iterator which can be used to iterate over all composite keys whose prefix
-//matches the given partial composite key. This function should be used only for
-//a partial composite key. For a full composite key, an iter with empty response
-//would be returned.
+//GetStateByPartialCompositeKey documentation can be found in interfaces.go
 func (s *ChaincodeStub) GetStateByPartialCompositeKey(objectType string, attributes []string) (StateQueryIteratorInterface, error) {
 	collection := ""
 	startKey, endKey, err := s.createRangeKeysForPartialCompositeKey(objectType, attributes)


### PR DESCRIPTION
Updated documentation for getStateByPartialCompositeKey, getStateByPartialCompositeKeyWithPagination and getPrivateDataByPartialCompositeKey.
Specified that we can't do a full key query: https://jira.hyperledger.org/browse/FABCN-376  