### PR TITLE
Suppress false positive in gosec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,7 @@ linters:
     - misspell
     - typecheck
     - unused
+linters-settings:
+  gosec:
+    excludes:
+      - 'G115' # safe to exclude type conversion overflow checks in this repository since the integer values will always be low


### PR DESCRIPTION
New versions of gosec implemented stricter type conversion. Since the integer values will be small in the conversions in this codebase, it is safe to suppress these gosec warnings.