### PR TITLE
Refactor write batching

### DIFF
--- a/shim/batch.go
+++ b/shim/batch.go
@@ -1,0 +1,69 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package shim
+
+import (
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+)
+
+type writeBatch struct {
+	writes map[string]*peer.WriteRecord
+}
+
+func newWriteBatch() *writeBatch {
+	return &writeBatch{
+		writes: make(map[string]*peer.WriteRecord),
+	}
+}
+
+func (b *writeBatch) Writes() []*peer.WriteRecord {
+	if b == nil {
+		return nil
+	}
+
+	var results []*peer.WriteRecord
+	for _, value := range b.writes {
+		results = append(results, value)
+	}
+
+	return results
+}
+
+func (b *writeBatch) PutState(collection string, key string, value []byte) {
+	b.writes[batchLedgerKey(collection, key)] = &peer.WriteRecord{
+		Key:        key,
+		Value:      value,
+		Collection: collection,
+		Type:       peer.WriteRecord_PUT_STATE,
+	}
+}
+
+func (b *writeBatch) PutStateMetadataEntry(collection string, key string, metakey string, metadata []byte) {
+	b.writes[batchLedgerKey(collection, key)] = &peer.WriteRecord{
+		Key:        key,
+		Collection: collection,
+		Metadata:   &peer.StateMetadata{Metakey: metakey, Value: metadata},
+		Type:       peer.WriteRecord_PUT_STATE_METADATA,
+	}
+}
+
+func (b *writeBatch) DelState(collection string, key string) {
+	b.writes[batchLedgerKey(collection, key)] = &peer.WriteRecord{
+		Key:        key,
+		Collection: collection,
+		Type:       peer.WriteRecord_DEL_STATE,
+	}
+}
+
+func (b *writeBatch) PurgeState(collection string, key string) {
+	b.writes[batchLedgerKey(collection, key)] = &peer.WriteRecord{
+		Key:        key,
+		Collection: collection,
+		Type:       peer.WriteRecord_PURGE_PRIVATE_DATA,
+	}
+}
+
+func batchLedgerKey(collection string, key string) string {
+	return prefixStateDataWriteBatch + collection + key
+}

--- a/shim/batch.go
+++ b/shim/batch.go
@@ -35,7 +35,7 @@ func (b *writeBatch) Writes() []*peer.WriteRecord {
 		return nil
 	}
 
-	var results []*peer.WriteRecord
+	results := make([]*peer.WriteRecord, 0, len(b.writes))
 	for _, value := range b.writes {
 		results = append(results, value)
 	}

--- a/shim/handler_test.go
+++ b/shim/handler_test.go
@@ -48,8 +48,6 @@ func TestNewHandler_CreatedState(t *testing.T) {
 		cc:               cc,
 		responseChannels: map[string]chan *peer.ChaincodeMessage{},
 		state:            created,
-		batch:            map[string]map[string]*peer.WriteRecord{},
-		startWriteBatch:  map[string]bool{},
 	}
 
 	handler := newChaincodeHandler(chatStream, cc)

--- a/shim/stub.go
+++ b/shim/stub.go
@@ -623,7 +623,7 @@ func (s *ChaincodeStub) GetQueryResultWithPagination(query string, pageSize int3
 
 // StartWriteBatch documentation can be found in interfaces.go
 func (s *ChaincodeStub) StartWriteBatch() {
-	if s.writeBatch == nil {
+	if s.handler.usePeerWriteBatch && s.writeBatch == nil {
 		s.writeBatch = newWriteBatch()
 	}
 }

--- a/shim/stub.go
+++ b/shim/stub.go
@@ -29,6 +29,7 @@ type ChaincodeStub struct {
 	signedProposal             *peer.SignedProposal
 	proposal                   *peer.Proposal
 	validationParameterMetakey string
+	writeBatch                 *writeBatch
 
 	// Additional fields extracted from the signedProposal
 	creator   []byte
@@ -167,7 +168,16 @@ func (s *ChaincodeStub) GetState(key string) ([]byte, error) {
 
 // SetStateValidationParameter documentation can be found in interfaces.go
 func (s *ChaincodeStub) SetStateValidationParameter(key string, ep []byte) error {
-	return s.handler.handlePutStateMetadataEntry("", key, s.validationParameterMetakey, ep, s.ChannelID, s.TxID)
+	return s.putStateMetadataEntry("", key, s.validationParameterMetakey, ep)
+}
+
+func (s *ChaincodeStub) putStateMetadataEntry(collection string, key string, metakey string, metadata []byte) error {
+	if s.writeBatch != nil {
+		s.writeBatch.PutStateMetadataEntry(collection, key, metakey, metadata)
+		return nil
+	}
+
+	return s.handler.handlePutStateMetadataEntry(collection, key, metakey, metadata, s.ChannelID, s.TxID)
 }
 
 // GetStateValidationParameter documentation can be found in interfaces.go
@@ -184,11 +194,22 @@ func (s *ChaincodeStub) GetStateValidationParameter(key string) ([]byte, error) 
 
 // PutState documentation can be found in interfaces.go
 func (s *ChaincodeStub) PutState(key string, value []byte) error {
+	// Access public data by setting the collection to empty string
+	collection := ""
+
+	return s.putState(collection, key, value)
+}
+
+func (s *ChaincodeStub) putState(collection string, key string, value []byte) error {
 	if key == "" {
 		return errors.New("key must not be an empty string")
 	}
-	// Access public data by setting the collection to empty string
-	collection := ""
+
+	if s.writeBatch != nil {
+		s.writeBatch.PutState(collection, key, value)
+		return nil
+	}
+
 	return s.handler.handlePutState(collection, key, value, s.ChannelID, s.TxID)
 }
 
@@ -218,6 +239,16 @@ func (s *ChaincodeStub) GetQueryResult(query string) (StateQueryIteratorInterfac
 func (s *ChaincodeStub) DelState(key string) error {
 	// Access public data by setting the collection to empty string
 	collection := ""
+
+	return s.delState(collection, key)
+}
+
+func (s *ChaincodeStub) delState(collection string, key string) error {
+	if s.writeBatch != nil {
+		s.writeBatch.DelState(collection, key)
+		return nil
+	}
+
 	return s.handler.handleDelState(collection, key, s.ChannelID, s.TxID)
 }
 
@@ -244,10 +275,8 @@ func (s *ChaincodeStub) PutPrivateData(collection string, key string, value []by
 	if collection == "" {
 		return fmt.Errorf("collection must not be an empty string")
 	}
-	if key == "" {
-		return fmt.Errorf("key must not be an empty string")
-	}
-	return s.handler.handlePutState(collection, key, value, s.ChannelID, s.TxID)
+
+	return s.putState(collection, key, value)
 }
 
 // DelPrivateData documentation can be found in interfaces.go
@@ -255,7 +284,8 @@ func (s *ChaincodeStub) DelPrivateData(collection string, key string) error {
 	if collection == "" {
 		return fmt.Errorf("collection must not be an empty string")
 	}
-	return s.handler.handleDelState(collection, key, s.ChannelID, s.TxID)
+
+	return s.delState(collection, key)
 }
 
 // PurgePrivateData documentation can be found in interfaces.go
@@ -263,6 +293,16 @@ func (s *ChaincodeStub) PurgePrivateData(collection string, key string) error {
 	if collection == "" {
 		return fmt.Errorf("collection must not be an empty string")
 	}
+
+	return s.purgeState(collection, key)
+}
+
+func (s *ChaincodeStub) purgeState(collection string, key string) error {
+	if s.writeBatch != nil {
+		s.writeBatch.PurgeState(collection, key)
+		return nil
+	}
+
 	return s.handler.handlePurgeState(collection, key, s.ChannelID, s.TxID)
 }
 
@@ -335,7 +375,7 @@ func (s *ChaincodeStub) GetPrivateDataValidationParameter(collection, key string
 
 // SetPrivateDataValidationParameter documentation can be found in interfaces.go
 func (s *ChaincodeStub) SetPrivateDataValidationParameter(collection, key string, ep []byte) error {
-	return s.handler.handlePutStateMetadataEntry(collection, key, s.validationParameterMetakey, ep, s.ChannelID, s.TxID)
+	return s.putStateMetadataEntry(collection, key, s.validationParameterMetakey, ep)
 }
 
 // CommonIterator documentation can be found in interfaces.go
@@ -583,12 +623,16 @@ func (s *ChaincodeStub) GetQueryResultWithPagination(query string, pageSize int3
 
 // StartWriteBatch documentation can be found in interfaces.go
 func (s *ChaincodeStub) StartWriteBatch() {
-	s.handler.handleStartWriteBatch(s.ChannelID, s.TxID)
+	if s.writeBatch == nil {
+		s.writeBatch = newWriteBatch()
+	}
 }
 
 // FinishWriteBatch documentation can be found in interfaces.go
 func (s *ChaincodeStub) FinishWriteBatch() error {
-	return s.handler.handleFinishWriteBatch(s.ChannelID, s.TxID)
+	err := s.handler.sendBatch(s.ChannelID, s.TxID, s.writeBatch.Writes())
+	s.writeBatch = nil
+	return err
 }
 
 // Next ...

--- a/shim/stub_test.go
+++ b/shim/stub_test.go
@@ -630,8 +630,6 @@ func TestChaincodeStubHandlers(t *testing.T) {
 				cc:                &mockChaincode{},
 				responseChannels:  map[string]chan *peer.ChaincodeMessage{},
 				state:             ready,
-				batch:             map[string]map[string]*peer.WriteRecord{},
-				startWriteBatch:   map[string]bool{},
 				usePeerWriteBatch: true,
 				maxSizeWriteBatch: 100,
 			}


### PR DESCRIPTION
Avoid holding transaction-specific state in the handler, which must then be protected by multiple locks. This is error prone and is a potential performance bottleneck. Instead, extract batch writes to a separate struct for clarity, and maintain the batch write state in the stub, which is unique to a specific transaction so requires no locking.

The stub (and associated batch write state) is also discarded after a transaction invocation so there is no risk of memory leaks due to redundant batch write state being left in the shared handler.