### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/cid/cid.go
+++ b/pkg/cid/cid.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"slices"
 
 	"github.com/hyperledger/fabric-chaincode-go/v2/pkg/attrmgr"
 	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
@@ -143,12 +144,7 @@ func (c *ClientID) HasOUValue(OUValue string) (bool, error) {
 		return false, fmt.Errorf("cannot obtain an X509 certificate for the identity")
 	}
 
-	for _, OU := range x509Cert.Subject.OrganizationalUnit {
-		if OU == OUValue {
-			return true, nil
-		}
-	}
-	return false, nil
+	return slices.Contains(x509Cert.Subject.OrganizationalUnit, OUValue), nil
 }
 
 // GetX509Certificate returns the X509 certificate associated with the client,


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.